### PR TITLE
update directive priority and replace transcluded element content if it exists

### DIFF
--- a/i18ng.js
+++ b/i18ng.js
@@ -59,11 +59,14 @@ angular.module('i18ng')
     }
 
     return {
+      priority: 100,
       restrict: 'A',
       link: function(scope, element, attrs) {
 
+        var transcludeElement = element.find('[ng-transclude]')
+        var elementToTranslate = transcludeElement.length ? transcludeElement : element
         var translations = {}
-        var t = translate.bind(null, scope, element, translations)
+        var t = translate.bind(null, scope, elementToTranslate, translations)
         var ignore = ['opts', 'html']
 
         angular.forEach(attrs, function(val, key) {
@@ -104,10 +107,10 @@ angular.module('i18ng')
         }
 
         scope.$on('i18ngInitComplete', function() {
-          translateAll(scope, element, translations)
+          translateAll(scope, elementToTranslate, translations)
         })
 
-        translateAll(scope, element, translations)
+        translateAll(scope, elementToTranslate, translations)
       }
     }
   }])


### PR DESCRIPTION
If an element included both an `i18ng` directive and another directive that used a transcluded template, the transcluded template was getting overwritten by the translation. Apparently, transcluded templates are rendered before directives are executed, so even with a higher priority, i18ng was still overwriting the html of the transclusion. The fix here adds the priority AND THEN looks for a `[ng-transclude]` element. It will apply the translation to the transclude element, or to the base element if one is not found.