### PR TITLE
Added function to call use() on i18ng and call these in order in i18n…

### DIFF
--- a/i18ng.js
+++ b/i18ng.js
@@ -29,7 +29,7 @@ angular.module('i18ng')
       var callback = options[1] || function () { }
       if (typeof opts === 'function') callback = opts, opts = {}
 
-      callUse().i18n.init.call(i18n, opts, function (t) {
+      callUse().init.call(i18n, opts, function (t) {
         i18n.t = t
         if (!$rootScope.$$phase)
           $rootScope.$digest()


### PR DESCRIPTION
Added ability to use i18next modules on initialisation.  Tested with XHRBackend and localStorageCache.

Odd thing is, I'm sure I saw a similar code change for i18ng that allowed a single use() to supply the backend module, but I can't see it in the official repo anywhere